### PR TITLE
fix texty and schedule-tester OPE-338

### DIFF
--- a/souls/multi-texting/soul/initialProcess.ts
+++ b/souls/multi-texting/soul/initialProcess.ts
@@ -51,7 +51,7 @@ const multiTexts: MentalProcess = async ({ workingMemory }) => {
       indentNicely`
         - Texty sends a sentence fragment, extending the train of thought from their last text
         - Make sure the fragment is ${lengthOfText} in length
-        - Their last text was: "${workingMemory.slice(-1)[0].value}"
+        - Their last text was: "${workingMemory.slice(-1).memories[0].content}"
       `,
       { model: "quality" }
     );

--- a/souls/schedule-tester/soul/initialProcess.ts
+++ b/souls/schedule-tester/soul/initialProcess.ts
@@ -2,16 +2,16 @@
 import { MentalProcess, useActions, usePerceptions } from "@opensouls/engine";
 import externalDialog from "./lib/externalDialog.js"
 
-const pokesSpeaker: MentalProcess = async ({ step: initialStep }) => {
+const pokesSpeaker: MentalProcess = async ({ workingMemory }) => {
   const { speak, scheduleEvent, log } = useActions()
   const { invokingPerception } = usePerceptions()
 
   if (invokingPerception?.action === "poked") {
     log("scheduled poke was received")
-    const [nextStep, stream] = await externalDialog(initialStep, "Ask the user how it felt to be poked?", { stream: true });
+    const [withPokeReceived, stream] = await externalDialog(workingMemory, "Ask the user how it felt to be poked?", { stream: true });
     speak(stream);
   
-    return nextStep;
+    return withPokeReceived;
   }
 
   if (!invokingPerception?.internal) {
@@ -26,10 +26,10 @@ const pokesSpeaker: MentalProcess = async ({ step: initialStep }) => {
     })
   }
 
-  const [nextStep, stream] = await externalDialog(initialStep, "Samantha tells the user she is gonna poke them in the future, in about 10 seconds.", { stream: true });
+  const [withGoingToPoke, stream] = await externalDialog(workingMemory, "Samantha tells the user she is gonna poke them in the future, in about 10 seconds.", { stream: true });
   speak(stream);
 
-  return nextStep;
+  return withGoingToPoke;
 }
 
 export default pokesSpeaker


### PR DESCRIPTION
small bugs in the cutover to the new API prevented using these two souls.