### PR TITLE
fix the typing of the decision step to allow for variables with strings OPE-345

### DIFF
--- a/library/cognitiveSteps/decision.ts
+++ b/library/cognitiveSteps/decision.ts
@@ -1,9 +1,10 @@
 import { createCognitiveStep, WorkingMemory, ChatMessageRoleEnum, indentNicely, stripEntityAndVerb, stripEntityAndVerbFromStream, z } from "@opensouls/engine";
 
-const decision = createCognitiveStep(({ description, choices, verb = "decided" }: { description: string, choices: z.EnumValues, verb?: string }) => {
+const decision = createCognitiveStep(({ description, choices, verb = "decided" }: { description: string, choices: z.EnumLike | string[], verb?: string }) => {
   const params = z.object({
-    decision: z.enum(choices).describe(`The decision made by the entity.`)
+    decision: z.nativeEnum(choices as z.EnumLike).describe(`The decision made by the entity.`)
   });
+
   return {
     schema: params,
     command: ({ soulName: name }: WorkingMemory) => {
@@ -24,7 +25,7 @@ const decision = createCognitiveStep(({ description, choices, verb = "decided" }
     },
     streamProcessor: stripEntityAndVerbFromStream,
     postProcess: async (memory: WorkingMemory, response: z.infer<typeof params>) => {
-      const stripped = stripEntityAndVerb(memory.soulName, verb, response.decision);
+      const stripped = stripEntityAndVerb(memory.soulName, verb, response.decision.toString());
       const newMemory = {
         role: ChatMessageRoleEnum.Assistant,
         content: `${memory.soulName} ${verb}: "${stripped}"`
@@ -32,6 +33,6 @@ const decision = createCognitiveStep(({ description, choices, verb = "decided" }
       return [newMemory, stripped];
     }
   }
-})
+});
 
 export default decision


### PR DESCRIPTION
i noticed this and then forgot about it, and then bootoshi saw it. This fixes typing so that if you have a variable of choices..

eg: `const choices = ["a", "b"]` you have to typecast that to use the existing decision step. This lets you use that variable.