### PR TITLE
docs: Alter potential spelling error

### DIFF
--- a/souls/raggy-knows-open-souls/README.md
+++ b/souls/raggy-knows-open-souls/README.md
@@ -2,7 +2,7 @@
 
 **Soul Designer:** [@tobowers](https://github.com/tobowers)
 
-This soul, named Raggy, is designed to demonstrate the buleprint-wide memory capabilities built into the soul engine. There are docs in the `/docs` directory and running `npm run docs:chunk` will move them into the `stores/docs` directory. `npm run docs:push` will sync the soul engine with the chunked docs.
+This soul, named Raggy, is designed to demonstrate the blueprint-wide memory capabilities built into the soul engine. There are docs in the `/docs` directory and running `npm run docs:chunk` will move them into the `stores/docs` directory. `npm run docs:push` will sync the soul engine with the chunked docs.
 
 Then, souls within the organization can access the information contained in those files.
 


### PR DESCRIPTION
Not sure if this was an error, but while reading through this doc it stuck out to me that "blueprint" might have been the intended verbiage here. Please accept this PR if you find it helpful.