### PR TITLE
add design philosophy document

### DIFF
--- a/docs/pages/design-philosophy.mdx
+++ b/docs/pages/design-philosophy.mdx
@@ -44,8 +44,8 @@ When researching new APIs or styles of working, we analyze neuroscience, psychol
 
 ## Extensible
 
-The Soul Engine interacts with your applications where they live, allowing you to build whatever you want, with an AI soul at the core (or periphery) of your project.
+The Soul Engine interacts with your applications and experiences where they live, allowing you to build whatever you want, with an AI soul at the core (or periphery) of your project. The mental state of your soul is hosted and processed by the Soul Engine, but your application could be a web app, a game, or an embdded device. Accessing your soul through an API allows for easier debugging, of your application, and a more straightforward way to sculpt the soul itself. The Soul Engine is designed to support your development from first idea to your production experience.
 
 ## Built to Connect Human / Machine
 
-The Soul Engine and its interfaces are generally written TypeScript, because the Soul Engine empowers creators to connect their community directly to an AI soul, and those touch points tend to have a javascript runtime.
+Frontend developers are the soul developers of tomorrow, because frontend engineering is the design of stateful systems close to where user interactions happen (apps, web, etc). The Soul Engine is TypeScript-first because it's the most popular language for frontend engineers.

--- a/docs/pages/design-philosophy.mdx
+++ b/docs/pages/design-philosophy.mdx
@@ -30,7 +30,7 @@ When possible, we re-use patterns already known to developers (React, for instan
 
 ## A Sculptor's Tool
 
-The Soul Engine is not a magic black box for AI soul creation. Instead, it allows developers to focus on the exact soul and experience they want to build. This enables rapid iteration and experimentation, making it fun. Soul developers gradually shape their experience, testing and debugging as they build and the soul engine should support them from first idea to production.
+The Soul Engine is not a magic black box for AI soul creation. Instead, it allows developers to focus on the exact soul and experience they want to build. This enables rapid iteration and experimentation, making it fun. Soul developers gradually shape their experience, testing and debugging as they build and the Soul Engine should support them from first idea to production.
 
 ## Reduce Friction
 
@@ -38,7 +38,7 @@ Every API added to the Soul Engine is designed to solve a specific problem encou
 
 ## Inspired by Nature
 
-The inner workings of the soul engine are inspired by our best research into how the human mind functions.
+The inner workings of the Soul Engine are inspired by our best research into how the human mind functions.
 
 When researching new APIs or styles of working, we analyze neuroscience, psychology, and intuitive self-understanding. These biological systems influence the design of the Soul Engine’s API.
 

--- a/docs/pages/design-philosophy.mdx
+++ b/docs/pages/design-philosophy.mdx
@@ -1,6 +1,6 @@
 # Design Philosophy
 
-A core belief of OPEN SOULS is that LLMs are amazing reasoning machines, similar to the prefrontal cortex of the brain, or the CPU of a computer, but lack the _rest of the brain_. The Soul Engine is the tool models the rest of the mind: agency, memory, emotion, drive, goal setting, and more.
+A core belief of OPEN SOULS is that LLMs are amazing reasoning machines, similar to the prefrontal cortex of the brain, or the CPU of a computer, but lack the _rest of the brain_. The Soul Engine is the tool for modeling the rest of the mind: giving agency, memory, emotion, drive, goal setting, and more.
 
 The Soul Engine optimizes for rich, soulful experiences. It is a developer tool and hosted service to create and deploy mind-blowing experiences with AI Souls.  It is a rich ecosystem of APIs for developers to craft and _host_ their AI Soul experiences.
 

--- a/docs/pages/design-philosophy.mdx
+++ b/docs/pages/design-philosophy.mdx
@@ -1,0 +1,51 @@
+# Design Philosophy
+
+A core belief of OPEN SOULS is that LLMs are amazing reasoning machines, similar to the prefrontal cortex of the brain, or the CPU of a computer, but lack the _rest of the brain_. The Soul Engine is the tool models the rest of the mind: agency, memory, emotion, drive, goal setting, and more.
+
+The Soul Engine optimizes for rich, soulful experiences. It is a developer tool and hosted service to create and deploy mind-blowing experiences with AI Souls.  It is a rich ecosystem of APIs for developers to craft and _host_ their AI Soul experiences.
+
+As a team and community, we make decisions about what goes into and what stays out of the Soul Engine. This document expresses our main goals and reasoning.
+
+## Simplicity
+
+No magic. Designing a mind is an inherently complex task, but understanding individual components of the Soul Engine should be straightforward.
+
+We prioritize simplicity of an individual API over reducing the number of APIs.
+
+We abstract only after real-world use.
+
+## Functional, Debuggable, Predictable
+
+The interactions with the engine should be functional whenever possible and default towards immutable where the developer experience is not weakened. When you interact with an API from the Soul Engine, you can anticipate how it will work and your interactions are debuggable.
+
+## Interaction over Accuracy
+
+We optimize for soul, not for chat bots.
+
+The goal of the Soul Engine is to allow developers to create the most unbelievably awesome experiences and model minds realistically. We will always trade off accuracy for personality, emotion, realism, and subjective quality of interaction.
+
+## Familiarity
+
+When possible, we re-use patterns already known to developers (React, for instance). We make the Soul Engine’s API clearer by re-using interfaces and elements developers are already familiar with.
+
+## A Sculptor's Tool
+
+The Soul Engine is not a magic black box for AI soul creation. Instead, it allows developers to focus on the exact soul and experience they want to build. This enables rapid iteration and experimentation, making it fun. Soul developers gradually shape their experience, testing and debugging as they build and the soul engine should support them from first idea to production.
+
+## Reduce Friction
+
+Every API added to the Soul Engine is designed to solve a specific problem encountered during years of building AI souls. When a developer encounters something hard or annoying to use, the Soul Engine should have a feature that makes it easier and/or more fun to accomplish the same goal.
+
+## Inspired by Nature
+
+The inner workings of the soul engine are inspired by our best research into how the human mind functions.
+
+When researching new APIs or styles of working, we analyze neuroscience, psychology, and intuitive self-understanding. These biological systems influence the design of the Soul Engine’s API.
+
+## Extensible
+
+The Soul Engine interacts with your applications where they live, allowing you to build whatever you want, with an AI soul at the core (or periphery) of your project.
+
+## Built to Connect Human / Machine
+
+The Soul Engine and its interfaces are generally written TypeScript, because the Soul Engine empowers creators to connect their community directly to an AI soul, and those touch points tend to have a javascript runtime.


### PR DESCRIPTION
Adds a Soul Engine design philosophy doc. This is designed to be similar in use to https://legacy.reactjs.org/docs/design-principles.html - a place we can point to when making decisions about an API.