### PR TITLE
fix: Remove double-entry for "FAQ" in docs

### DIFF
--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -6,7 +6,7 @@
   "blueprints": "Blueprints",
   "souls": "Souls",
   "core": "Open Souls Core",
-  "faq": "FAQ"
+  "FAQ": "FAQ"
 }
 
 


### PR DESCRIPTION
<img width="179" alt="Screenshot 2024-06-03 at 10 39 20 AM" src="https://github.com/opensouls/community/assets/19847545/2affb340-4220-408f-aba6-a3da8930a2f0">
