### PR TITLE
make summarizer from library pin just one memory

### DIFF
--- a/library/subprocesses/summarizeConversation.ts
+++ b/library/subprocesses/summarizeConversation.ts
@@ -86,7 +86,7 @@ const summarizesConversation: MentalProcess = async ({ workingMemory }) => {
     conversationModel.current = updatedNotes as string
 
     return workingMemory
-      .slice(0,2)
+      .slice(0,1)
       .withMemory({
         role: ChatMessageRoleEnum.Assistant,
         content: indentNicely`


### PR DESCRIPTION
i know the second memory there was because of withRagContext but the reasoning here is that in most cases people won't use rag

alternatively we can just wait until we have the new memory system which should probably allow the creation of a more agnostic solution for this