### PR TITLE
in an update meta was broken slightly - fixed here

### DIFF
--- a/souls/metatention/soul/initialProcess.ts
+++ b/souls/metatention/soul/initialProcess.ts
@@ -54,6 +54,7 @@ const generateIntention = createCognitiveStep((goal: string) => {
 const provokesSpeaker: MentalProcess = async ({ workingMemory }) => {
   const { speak, log } = useActions()
   const { invocationCount } = useProcessManager()
+  const initialmemory = workingMemory
   const intention = useProcessMemory(indentNicely`
   # Sense of self
   Meta is unsure who they are
@@ -99,7 +100,7 @@ const provokesSpeaker: MentalProcess = async ({ workingMemory }) => {
   log("Updated directive")
   intention.current = updatedIntention
 
-  return workingMemory.withMemory({
+  return initialmemory.withMemory({
     role: ChatMessageRoleEnum.Assistant,
     content: indentNicely`
       Meta said: ${await speech}


### PR DESCRIPTION
Meta is not supposed to add any of its mental model to the working memory in this particular concept of memory design - the idea is that the model is essentially pinned right before the previous messages

In one of the updates, the model kept getting added every other msg